### PR TITLE
Rewrite useLiveValue

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,24 +25,6 @@ function ShowCount(props: {
 
 When updating the `value` property, the usual React rules apply for registering the update: the actual value of the property must change, and if the value is an Object or Array, a different Object or Array identity must be assigned.
 
-A `LiveValue` may be constructed with a function argument, which may in turn reference the `value` property of other `LiveValue` objects.  In this case, the `LiveValue` will be updated if any of those "dependencies" changes value, and any `useLiveValue` hooks referencing that `LiveValue` will force their components to re-render.
-
-For example:
-
-```
-const counter1 = new LiveValue(0);
-setInterval(()=>counter1.value++, 1000);
-
-const counter2 = new LiveValue(0);
-setInterval(()=>counter2.value++, 700);
-
-const counterSum = new LiveValue(()=>counter1.value + counter2.value)
-```
-
-Here there are two `LiveValue` objects whose values are incrementing at varying rates, and a third `LiveValue` computes the sum of the two.  If the `counterSum` is passed to the `ShowCount` component above, that component will re-render whenever either of those counters changes value.
-
-When a function is passed to a `LiveValue`, that function is not evaluated until the first time the `value` property is accessed.  Its result is cached and returned with subsequent `value` calls until one of the dependencies changes, at which point that cached value is removed.  After that, the function is not re-evaluated until the next time `value` is accessed.
-
 ### Additional Notification API's
 
 `LiveValue` provides a simple API that allows applications to be notified when a value may have changed, either because the `value` was set directly, or because a dependency's value changed.  This effectively offers applications the same ability given to the `useLiveValue` hook:

--- a/src/DependencyTracker.ts
+++ b/src/DependencyTracker.ts
@@ -42,7 +42,7 @@ class _DependencyTracker {
   }
 
   get currentDependent(): ComputedValue<any> | null {
-    return this.stack.length == 0 ? null : this.stack[this.stack.length - 1]
+    return this.stack.length === 0 ? null : this.stack[this.stack.length - 1]
   }
 }
 

--- a/src/LiveValueDebug.ts
+++ b/src/LiveValueDebug.ts
@@ -71,7 +71,7 @@ export class _LiveValueDebug {
         return `Removed listener "${e.listenerName}" from LiveValue "${e.liveValueName}"`
       case "NotifyingListeners":
         return `Notifying ${e.listenerCount} listener${
-          e.listenerCount == 1 ? "" : "s"
+          e.listenerCount === 1 ? "" : "s"
         } of LiveValue "${e.liveValueName}"`
       case "NotifyingListener":
         return `Notifying listener "${e.listenerName}" of LiveValue "${e.liveValueName}"`

--- a/src/tests/LiveValueDebug.spec.ts
+++ b/src/tests/LiveValueDebug.spec.ts
@@ -96,10 +96,6 @@ describe("LiveValueDebug", () => {
         `Rerendering useLiveValue "useLiveValue#4"`,
         `Unmounting useLiveValue "useLiveValue#4"`,
         `Disconnecting useLiveValue "useLiveValue#4" from LiveValue "LiveValue#1"`,
-        `LiveValue "LiveValue#1" no longer depends on LiveValue "lv1"`,
-        `Removed listener "LiveValue#1" from LiveValue "lv1"`,
-        `LiveValue "LiveValue#1" no longer depends on LiveValue "lv2"`,
-        `Removed listener "LiveValue#1" from LiveValue "lv2"`,
         `Removed listener "useLiveValue#4" from LiveValue "LiveValue#1"`,
       ]
       expect(expected).toEqual(msgs)

--- a/src/tests/useLiveValue.spec.ts
+++ b/src/tests/useLiveValue.spec.ts
@@ -109,7 +109,7 @@ describe("useLiveValue", () => {
       expect(result.result.all.length).toBe(1)
       expect(result.result.current).toBe(10)
     })
-    it("move its listener if rendered with a new LiveValue", () => {
+    it("create a new listener if rendered with a new LiveValue", () => {
       const lv1 = new LiveValue(10)
       const result = renderHook((lv: LiveValue<number>) => useLiveValue(lv), {
         initialProps: lv1,
@@ -124,9 +124,9 @@ describe("useLiveValue", () => {
 
       expect(listenerCount(lv1)).toBe(0)
       expect(listenerCount(lv2)).toBe(1)
-      expect(firstListener(lv2)).toBe(l1)
+      expect(firstListener(lv2)).not.toBe(l1)
 
-      expect(result.result.all).toEqual([10, 50])
+      expect(result.result.all).toEqual([10, 10, 50])
       expect(result.result.current).toBe(50)
     })
   })
@@ -151,29 +151,6 @@ describe("useLiveValue", () => {
       })
       expect(result.result.all.length).toBe(3)
       expect(result.result.current).toBe(5)
-    })
-  })
-  describe("with a function", () => {
-    it("should use the value computed from the specified function", () => {
-      let fcount = 0
-      const f = () => {
-        fcount++
-        return 10
-      }
-
-      const result = renderHook(
-        (lv: LiveValue<number> | (() => number)) => useLiveValue(lv),
-        {initialProps: f}
-      )
-      expect(result.result.all.length).toBe(1)
-      expect(result.result.current).toBe(10)
-      expect(fcount).toBe(1)
-
-      // It shouldn't call the function again
-      result.rerender(f)
-      expect(result.result.all.length).toBe(2)
-      expect(result.result.current).toBe(10)
-      expect(fcount).toBe(1)
     })
   })
 })


### PR DESCRIPTION
Rewrote useLiveValue to make more typical use of useState and useEffect.  Avoids missing the initial update.

Removed the ability to pass a function into useLiveValue - turns out that was causing a re-render every time, since a new function was being created each time.

Fixed a couple style issues.